### PR TITLE
Feature/provider section by system

### DIFF
--- a/public/assets/data/providerEducationReferences_demo.json
+++ b/public/assets/data/providerEducationReferences_demo.json
@@ -1,0 +1,37 @@
+{
+    "ProviderEducationMaterials" :
+        [
+            {
+                "link": {
+                    "title": "Clarification of Opioid Prescribing Rules",
+                    "className": "education",
+                    "url": "https://doh.wa.gov/public-health-healthcare-providers/healthcare-professions-and-facilities/opioid-prescribing/healthcare-providers"
+                }
+            },
+            {
+                "link": {
+                    "title": "UW Center for Pain Relief TelePain Consultation Hotline (848) XXX-XXXX",
+                    "subtitle": "for one-to-one specialist help for pain management and prescribing",
+                    "titleClassName": "text-alert",
+                    "className": "education",
+                    "url": ""
+                }
+            },
+            {
+                "link": {
+                    "title": "Participate in TelePain Wednesday launch time sessions",
+                    "subtitle": "sign up to join didactic discussions around pain assessment and management, opioid prescribing, getting the most out of regulations, gain CME credit, and more",
+                    "className": "education",
+                    "url": "https://depts.washington.edu/anesth/care/pain/telepain/mini-site/connect.shtml"
+                }
+            },
+            {
+                "link": {
+                    "title": "Browse previous 20-minute TelePain sessions to see what they are all about",
+                    "className": "education",
+                    "url": "https://depts.washington.edu/anesth/care/pain/telepain/mini-site/recorded-didactic-presentations.shtml"
+                }
+            }
+        ]
+
+}

--- a/src/components/Landing.js
+++ b/src/components/Landing.js
@@ -356,6 +356,7 @@ export default class Landing extends Component {
   async getExternalData() {
     let dataSet = {};
     const promiseResultSet = [];
+    const systemType = String(getEnv("REACT_APP_SYSTEM_TYPE")).toLowerCase();
 
     /*
      * retrieve entries from Summary map, i.e. summary.json that requires fetching data via external API
@@ -363,6 +364,10 @@ export default class Landing extends Component {
     for (let key in summaryMap) {
       if (summaryMap[key].dataSource) {
         summaryMap[key].dataSource.forEach(item => {
+          if (item.endpoint && typeof item.endpoint === "object") {
+            if (item.endpoint[systemType]) item.endpoint = item.endpoint[systemType];
+            else item.endpoint  = item.endpoint["default"];
+          }
           promiseResultSet.push(item);
         });
       }

--- a/src/components/summary.json
+++ b/src/components/summary.json
@@ -1308,7 +1308,10 @@
     "title":"Provider Resources",
     "skipDataInfo": true,
     "dataSource": [{
-      "endpoint": "{process.env.PUBLIC_URL}/assets/data/providerEducationReferences.json",
+      "endpoint": {
+        "demo" : "{process.env.PUBLIC_URL}/assets/data/providerEducationReferences_demo.json",
+        "default": "{process.env.PUBLIC_URL}/assets/data/providerEducationReferences.json"
+      },
       "dataKey": "ProviderEducationMaterials",
       "dataKeySource": "EducationMaterials"
     }],

--- a/src/helpers/formatit.js
+++ b/src/helpers/formatit.js
@@ -149,7 +149,7 @@ export function linkFormat(result, input) {
     </React.Fragment>
   );
   // if no link URL, just display the content without the link
-  if (!referenceURL) return (<div className="link-container">{renderLinkContent()}</div>);
+  if (!referenceURL) return (<div>{renderLinkContent()}</div>);
   return (
     <div className="link-container">
         <a href={referenceURL} target='_blank' rel='noopener noreferrer' className={input['className']}>

--- a/src/helpers/formatit.js
+++ b/src/helpers/formatit.js
@@ -148,6 +148,7 @@ export function linkFormat(result, input) {
       )}
     </React.Fragment>
   );
+  // if no link URL, just display the content without the link
   if (!referenceURL) return (<div className="link-container">{renderLinkContent()}</div>);
   return (
     <div className="link-container">

--- a/src/helpers/formatit.js
+++ b/src/helpers/formatit.js
@@ -116,6 +116,7 @@ export function stringSubstitutionFormat(result, input, replacement) {
  */
 export function linkFormat(result, input) {
   let isVideoLink = input['type'] === 'video' && input['embedVideoSrc'];
+  const referenceURL = input["url"];
   if (isVideoLink) {
     return (
         <VideoLink
@@ -126,18 +127,32 @@ export function linkFormat(result, input) {
         />
     );
   }
+  const renderLinkContent = () => (
+    <React.Fragment>
+      <div>
+        <span
+          className={`title ${
+            input["titleClassName"] ? input["titleClassName"] : ""
+          }`}
+        >
+          {input["title"]}
+        </span>
+        {input["type"] === "PDF" && (
+          <span className="text-muted info">
+            ({input["type"]}, size: {input["size"]})
+          </span>
+        )}
+      </div>
+      {input["subtitle"] && (
+        <div className="subtitle-container text-muted">{input["subtitle"]}</div>
+      )}
+    </React.Fragment>
+  );
+  if (!referenceURL) return (<div className="link-container">{renderLinkContent()}</div>);
   return (
     <div className="link-container">
-        <a href={input['url']} target='_blank' rel='noopener noreferrer' className={input['className']}>
-          <div>
-            <span className={`title ${input['titleClassName'] ? input['titleClassName']: ""}`}>{input['title']}</span>
-            {
-              input['type'] === "PDF" && <span className="text-muted info">({input['type']}, size: {input['size']})</span>
-            }
-          </div>
-          {
-            input['subtitle'] && <div className="subtitle-container text-muted">{input['subtitle']}</div>
-          }
+        <a href={referenceURL} target='_blank' rel='noopener noreferrer' className={input['className']}>
+          {renderLinkContent()}
          </a>
     </div>
   );


### PR DESCRIPTION
Changes include:
- allow provider education material section to differ based on system type as specified by configuration, i.e. `REACT_APP_SYSTEM_TYPE`
- if system type is `demo`,  demo system specific provider education material content will be displayed, i.e.
[public/assets/data/providerEducationReferences_demo.json](https://github.com/uwcirg/cosri-pain-management-summary/pull/149/files#diff-c27b7530029335241d971b08328f5272759f63fe279756e947de2561f201fcc8)

example output:
![Screen Shot 2022-10-27 at 12 31 50 PM](https://user-images.githubusercontent.com/12942714/198381735-f103d0eb-1a98-4282-8fbe-d4ce3d3d31fc.png)


