### PR TITLE
Remove DockerHub

### DIFF
--- a/.github/workflows/docker-cd.yaml
+++ b/.github/workflows/docker-cd.yaml
@@ -31,17 +31,3 @@ jobs:
           # create docker image tags to match git tags
           tag_names: true
           buildargs: VERSION_STRING
-
-      # # TODO remove after every *-environments migrated to GHCR
-      - name: Publish to Dockerhub registry
-        # todo: pin to hash
-        uses: elgohr/Publish-Docker-Github-Action@master
-        with:
-          # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions
-          name: ${{ secrets.DOCKER_REPO }}
-          # configured at repo settings/secrets
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-          # create docker image tags to match git tags
-          tag_names: true
-          buildargs: REACT_APP_VERSION_STRING

--- a/.github/workflows/docker-cd.yaml
+++ b/.github/workflows/docker-cd.yaml
@@ -15,6 +15,24 @@ jobs:
       - name: Set environment variable for version from git output
         run: echo "REACT_APP_VERSION_STRING=$(git describe --always --tags)" >> $GITHUB_ENV
 
+      - name: Publish to GitHub Container Registry
+        # TODO: pin to hash
+        uses: elgohr/Publish-Docker-Github-Action@master
+        with:
+          name: ${{ github.repository }}
+          registry: ghcr.io
+
+          # GitHub actor
+          username: ${{ github.actor }}
+
+          # GitHub access token
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+          # create docker image tags to match git tags
+          tag_names: true
+          buildargs: VERSION_STRING
+
+      # # TODO remove after every *-environments migrated to GHCR
       - name: Publish to Dockerhub registry
         # todo: pin to hash
         uses: elgohr/Publish-Docker-Github-Action@master


### PR DESCRIPTION
- Remove DockerHub as secondary image registry
- Only merge after uwcirg/cosri-pain-management-summary/pull/150, once every *-environments repo is using GHCR (instead of DockerHub)