### PR TITLE
add CDC related text changes

### DIFF
--- a/src/components/ExclusionBanner.js
+++ b/src/components/ExclusionBanner.js
@@ -6,12 +6,13 @@ export default class ExclusionBanner extends Component {
   constructor() {
     super(...arguments);
     this.state = {
-      displayed: true
+      displayed: false
     };
     this.handleCloseToggle= this.handleCloseToggle.bind(this);
   }
 
-  handleClose = () => {
+  handleClose = (e) => {
+    e.stopPropagation();
     this.setState({ displayed: false });
   }
 
@@ -28,11 +29,29 @@ export default class ExclusionBanner extends Component {
       <div
         className={`exclusion-banner banner ${conditionalClass}`}
         role="banner"
-        onClick={this.handleCloseToggle}>
+        onClick={this.handleCloseToggle}
+        onKeyDown={this.handleCloseToggle}
+      >
         <ChevronDownIcon className="close-button" icon="times" title="close"  width="25" height="25" />
 
         <div className="exclusion-banner__description">
-          <strong className="title"><FontAwesomeIcon icon="exclamation-circle" title="notice" /> LIMITATIONS</strong> <span className="content">Guidance <b>not intended</b> for <b>palliative</b>, <b>inpatient</b>, or <b>active cancer care</b>.</span>
+          <strong className="title"><FontAwesomeIcon icon="exclamation-circle" title="notice" /> LIMITATIONS</strong> Guidance for adult pain except... <span className="info-icon" role="button">(click here)</span>.
+          <div className="content">
+            <p>CDC's 2022 Clinical Practice Guideline <strong>applies</strong> to outpatients aged 18 years and older with:</p>
+            <ul>
+                <li>Acute pain (duration less than 1 month)</li>
+                <li>Subacute pain (duration of 1-3 months)</li>
+                <li>Chronic pain (duration of 3 months or more)</li>
+            </ul>
+            <p>It does <strong>not</strong> apply to management of patients</p>
+            <ul>
+                <li>with Sickle cell disease</li>
+                <li>with Cancer-related pain</li>
+                <li>receiving Palliative care</li>
+                <li>receiving End-of-life care</li>
+            </ul>
+            <div class="text-right"><button className="plain info-icon" onClick={this.handleClose}>Click to hide info</button></div>
+          </div>
         </div>
       </div>
     );

--- a/src/components/graph/MMEGraph.js
+++ b/src/components/graph/MMEGraph.js
@@ -133,7 +133,7 @@ export default class MMEGraph extends Component {
     const parentHeight = 344;
     const WA_MAX_VALUE = 120;
     const CDC_SECONDARY_MAX_VALUE = 50;
-    const CDC_MAX_VALUE = 90;
+    //const CDC_MAX_VALUE = 90;
     const xIntervals = 12;
     let lineParamsSet = [xIntervals, xFieldName, yFieldName];
     const hasError = this.props.error;
@@ -213,7 +213,7 @@ export default class MMEGraph extends Component {
 
     let WAData = this.getDefaultDataValueSet(WA_MAX_VALUE, baseLineDate, maxDate, ...lineParamsSet);
     let CDCSecondaryData = this.getDefaultDataValueSet(CDC_SECONDARY_MAX_VALUE, baseLineDate, maxDate, ...lineParamsSet);
-    let CDCData = this.getDefaultDataValueSet(CDC_MAX_VALUE, baseLineDate, maxDate, ...lineParamsSet);
+    //let CDCData = this.getDefaultDataValueSet(CDC_MAX_VALUE, baseLineDate, maxDate, ...lineParamsSet);
 
     const margins = {
       top: 8,
@@ -328,10 +328,10 @@ export default class MMEGraph extends Component {
               <Line lineID="dataLine" data={data} {...dataLineProps} />
               <Line lineID="WALine" strokeColor={WA_COLOR} dotted="true" dotSpacing="3, 3" data={WAData} {...defaultProps} />
               <Line lineID="CDCSecondaryLine" strokeColor={CDC_COLOR} dotted="true" dotSpacing="3, 3" data={CDCSecondaryData} {...defaultProps} />
-              <Line lineID="CDCLine" strokeColor={CDC_COLOR} dotted="true" dotSpacing="3, 3" data={CDCData} {...defaultProps} />
-              <text {...WALegendSettings}>Washington State consultation threshold</text>
-              <text {...CDCLegendSettings} y={yScale(50 + textMargin)}>CDC extra precautions threshold</text>
-              <text {...CDCLegendSettings} y={yScale(90 + textMargin)}>CDC avoid/justify threshold</text>
+              {/* <Line lineID="CDCLine" strokeColor={CDC_COLOR} dotted="true" dotSpacing="3, 3" data={CDCData} {...defaultProps} /> */}
+              <text {...WALegendSettings}>WA State: Consultation threshold</text>
+              <text {...CDCLegendSettings} y={yScale(50 + textMargin)}>CDC: Consider offering naloxone</text>
+              {/* <text {...CDCLegendSettings} y={yScale(90 + textMargin)}>CDC avoid/justify threshold</text> */}
             </g>
           </svg>
         </div>

--- a/src/styles/elements/_banners.scss
+++ b/src/styles/elements/_banners.scss
@@ -22,6 +22,11 @@
     text-align: left;
     background-color: $color-beige;
     position: relative;
+    .info-icon {
+      color: $color-blue;
+      cursor: pointer;
+      font-size: 0.95rem;
+    }
     &.warning {
       background-color: $color-red-darker;
     }
@@ -60,6 +65,9 @@
     }
     .content {
       display: inline;
+      strong {
+        color: #444;
+      }
     }
     &.close {
       .close-button {

--- a/src/styles/elements/_base.scss
+++ b/src/styles/elements/_base.scss
@@ -60,6 +60,9 @@ a {
 .text-center {
   text-align: center;
 }
+.text-right {
+  text-align: right;
+}
 .small {
   font-size: 14px;
   font-weight: 500;

--- a/src/styles/elements/_button.scss
+++ b/src/styles/elements/_button.scss
@@ -23,3 +23,8 @@
 button.disabled {
     opacity: 0.5
 }
+button.plain {
+    background-color: transparent;
+    border:0;
+    background-image: none;
+}


### PR DESCRIPTION
Per [Slack convo](https://cirg.slack.com/archives/C01P9V67NMA/p1723055082632559)

- remove CDC avoid/justify threshold line (at 99mme)
- re-label CDC extra precautions threshold (at 50 mme) to "CDC: consider offering naloxone"
- re-label WA state threshold to "WA State:  Consultation Threshold"
(see screenshot)
![Screenshot 2024-08-07 at 1 21 59 PM](https://github.com/user-attachments/assets/425c62ac-c8f7-4d4c-aec5-619efb4907ec)

- update limitation text (see screenshot)

collapased view: 
![Screenshot 2024-08-07 at 2 05 26 PM](https://github.com/user-attachments/assets/c06aaef0-be93-4940-83b3-3fb73f0c8fb3)
expanded view:
![Screenshot 2024-08-07 at 2 05 39 PM](https://github.com/user-attachments/assets/9199c410-5f30-493e-a355-86211379d667)

