### PR TITLE
anchor link fix

### DIFF
--- a/src/components/Summary.js
+++ b/src/components/Summary.js
@@ -197,7 +197,15 @@ export default class Summary extends Component {
           top: isReportEnabled() ? "-148px" : "-100px",
           height: "2px",
         }}
-      ></div>
+      >
+        {/* eslint-disable-next-line */}
+        <a
+          name={`${sectionId}_anchor`}
+          href={`#${sectionId}`}
+          tabIndex={0}
+          aria-hidden="true"
+        ></a>
+      </div>
     );
   }
 


### PR DESCRIPTION
found while testing that the go to section links  in the alert panel (see screenshot) are no longer working.

![Screenshot 2024-08-23 at 10 23 30 AM](https://github.com/user-attachments/assets/8e3c627d-48d9-4976-a0b3-f803126801f6)

Fix include:
- add back the anchor link containing the `name` and `href attributes