### PR TITLE
section title - use questionnaire title if applicable

### DIFF
--- a/src/components/Report/index.js
+++ b/src/components/Report/index.js
@@ -164,13 +164,14 @@ export default class Report extends Component {
           id={`${itemKey}_title`}
           className="sub-section__header"
         >
-          {this.renderSubSectionTitle(item)}
+          {this.renderSubSectionTitle(item, summaryData)}
           {this.renderSubSectionInfo(item, summaryData)}
         </h3>
       </React.Fragment>
     );
   }
-  renderSubSectionTitle(item) {
+  renderSubSectionTitle(item, summaryData) {
+    const title = summaryData?.Questionnaire?.title?.value??item.title;
     return (
       <span
         className="sub-section__header__name"
@@ -183,7 +184,7 @@ export default class Report extends Component {
           title="flag"
           tabIndex={0}
         /> */}
-        {item.title}
+        {title}
       </span>
     );
   }

--- a/src/config/report_config.js
+++ b/src/config/report_config.js
@@ -438,7 +438,7 @@ const reportConfig = [
       },
       {
         dataKey: TRT_DATA_KEY,
-        title: "PainTracker TRT questionnaire",
+        title: "Patient-reported Treatments Questionnaire",
         description: () => (
           <div>
             <p>


### PR DESCRIPTION
For sections rendering questionnaire responses, use title provided in FHIR Questionnaire json if present.  The title provided in `report_config` is the default.