### PR TITLE
minor table styling fix

### DIFF
--- a/src/styles/elements/_tables.scss
+++ b/src/styles/elements/_tables.scss
@@ -174,3 +174,13 @@
     }
   }
 }
+
+.two-columns {
+  .table {
+    table-layout: auto !important;
+    th:first-of-type,
+    td:first-of-type {
+      width: 60%;
+    }
+  }
+}


### PR DESCRIPTION
Increase width of first column for responses table with two columns (see screenshot after changes):
![Screenshot 2024-09-19 at 1 31 27 PM](https://github.com/user-attachments/assets/dd2e74a0-9bdc-474a-9215-a2f8063f8fe6)
