### PR TITLE
update conversion factors for tramadol and hydromorphone

### DIFF
--- a/src/cql/r4/OMTKLogic.cql
+++ b/src/cql/r4/OMTKLogic.cql
@@ -114,7 +114,7 @@ Fentanyl, transdermal patch (MCG/HR)	2.4
 Fentanyl, Injection 1
 Fentanyl, Lozenge Product 0.13
 Hydrocodone	1
-Hydromorphone	4
+Hydromorphone	5
 Levomethadyl acetate	8
 Levorphanol tartrate	11
 Meperidine 	0.1
@@ -129,7 +129,7 @@ Oxycodone	1.5
 Oxymorphone	3
 Pentazocine	0.37
 Tapentadol	0.4
-Tramadol	0.1
+Tramadol	0.2
 Benzhydrocodone 1.22
 Oliceridine 5
 */
@@ -158,7 +158,7 @@ define function GetConversionFactor(ingredientCode Code, dailyDose Quantity, dos
     when 2400 then 0 /*	Chlorpheniramine */
     when 3500 then 0.15 /*	Diphenoxylate */
     when 2670 then 0.15 /*	Codeine */
-    when 3423 then 4 /*	Hydromorphone */
+    when 3423 then 5 /*	Hydromorphone */
     when 3498 then 0 /*	Diphenhydramine */
     when 56795 then ( /* Sufentanil */
       case
@@ -215,7 +215,7 @@ define function GetConversionFactor(ingredientCode Code, dailyDose Quantity, dos
     when 8745 then 0 /*	Promethazine */
     when 8896 then 0 /*	Pseudoephedrine */
     when 9009 then 0 /*	Pyrilamine */
-    when 10689 then 0.1 /*	Tramadol */
+    when 10689 then 0.2 /*	Tramadol */
     when 10849 then 0 /*	Triprolidine */
     when 19759 then 0 /*	bromodiphenhydramine */
     when 19860 then 0 /*	butalbital */

--- a/src/cql/r4/OMTKLogic.cql
+++ b/src/cql/r4/OMTKLogic.cql
@@ -37,7 +37,7 @@ Epub 2011 Apr 21. PubMed PMID: 21515544; PubMed Central PMCID: PMC3128404.
 * 09/21/21 BugFix fix integer/decimal daily dose comparison when detetermine conversion factor for Methodone
 * 12/01/21 Add conversion factor for Sufentanil, Alfentanil, and Remifentanil
 * 12/21/21 Add conversion factor for Diphenoxylate
-* 10/09/24 Change conversion factor for Hydromorphone (from 4 to 6), for Tramadol (from 0.1 to 0.2), for buprenorphine (from 1.8 X 7 = 12.6 to 2.2 X 7 = 15.4 )
+* 10/09/24 Change conversion factor for Hydromorphone (from 4 to 6), for Tramadol (from 0.1 to 0.2), for buprenorphine patch (from 1.8 X 7 = 12.6 to 2.2 X 7 = 15.4, as patch remains in place for 7 days)
 */
 
 include OMTKData version '3.0.0' called OMTKData

--- a/src/cql/r4/OMTKLogic.cql
+++ b/src/cql/r4/OMTKLogic.cql
@@ -37,6 +37,7 @@ Epub 2011 Apr 21. PubMed PMID: 21515544; PubMed Central PMCID: PMC3128404.
 * 09/21/21 BugFix fix integer/decimal daily dose comparison when detetermine conversion factor for Methodone
 * 12/01/21 Add conversion factor for Sufentanil, Alfentanil, and Remifentanil
 * 12/21/21 Add conversion factor for Diphenoxylate
+* 10/09/24 Change conversion factor for Hydromorphone (from 4 to 6), for Tramadol (from 0.1 to 0.2)
 */
 
 include OMTKData version '3.0.0' called OMTKData

--- a/src/cql/r4/OMTKLogic.cql
+++ b/src/cql/r4/OMTKLogic.cql
@@ -37,7 +37,7 @@ Epub 2011 Apr 21. PubMed PMID: 21515544; PubMed Central PMCID: PMC3128404.
 * 09/21/21 BugFix fix integer/decimal daily dose comparison when detetermine conversion factor for Methodone
 * 12/01/21 Add conversion factor for Sufentanil, Alfentanil, and Remifentanil
 * 12/21/21 Add conversion factor for Diphenoxylate
-* 10/09/24 Change conversion factor for Hydromorphone (from 4 to 6), for Tramadol (from 0.1 to 0.2), for buprenorphine (from 1.8 X 7 = 12.6 to 2.2 X 7 )
+* 10/09/24 Change conversion factor for Hydromorphone (from 4 to 6), for Tramadol (from 0.1 to 0.2), for buprenorphine (from 1.8 X 7 = 12.6 to 2.2 X 7 = 15.4 )
 */
 
 include OMTKData version '3.0.0' called OMTKData

--- a/src/cql/r4/OMTKLogic.cql
+++ b/src/cql/r4/OMTKLogic.cql
@@ -37,7 +37,7 @@ Epub 2011 Apr 21. PubMed PMID: 21515544; PubMed Central PMCID: PMC3128404.
 * 09/21/21 BugFix fix integer/decimal daily dose comparison when detetermine conversion factor for Methodone
 * 12/01/21 Add conversion factor for Sufentanil, Alfentanil, and Remifentanil
 * 12/21/21 Add conversion factor for Diphenoxylate
-* 10/09/24 Change conversion factor for Hydromorphone (from 4 to 6), for Tramadol (from 0.1 to 0.2)
+* 10/09/24 Change conversion factor for Hydromorphone (from 4 to 6), for Tramadol (from 0.1 to 0.2), for buprenorphine (from 1.8 X 7 = 12.6 to 2.2 X 7 )
 */
 
 include OMTKData version '3.0.0' called OMTKData
@@ -98,7 +98,7 @@ https://www.cdc.gov/drugoverdose/modules/data-files.html
 CMS Guidance:
 https://www.cms.gov/Medicare/Prescription-Drug-Coverage/PrescriptionDrugCovContra/Downloads/Oral-MME-CFs-vFeb-2018.pdf
 Opioid (strength in mg except where noted)	MME Conversion Factor*
-Buprenorphine, transdermal patch (MCG/HR)	12.6
+Buprenorphine, transdermal patch (MCG/HR)	15.4 (2.2 X 7)
 Buprenorphine, tablet or film	30
 Buprenorphine, film (MCG)	0.03
 Butorphanol	7
@@ -148,7 +148,8 @@ define function GetConversionFactor(ingredientCode Code, dailyDose Quantity, dos
     when 1767 then 0 /*	Brompheniramine */
     when 1819 then ( /*	Buprenorphine */
       case
-        when ToInteger(doseFormCode.code) = 316987 then 12.6 /* Transdermal system */
+        //2.2 X 7 = 15.4
+        when ToInteger(doseFormCode.code) = 316987 then 15.4 /* Transdermal system */
         else 30 /* Tablet or Film (or Film in MCG) */
       end
     )

--- a/src/cql/r4/OMTKLogic.json
+++ b/src/cql/r4/OMTKLogic.json
@@ -1455,7 +1455,7 @@
                      "type" : "ToDecimal",
                      "operand" : {
                         "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                        "value" : "4",
+                        "value" : "5",
                         "type" : "Literal"
                      }
                   }
@@ -2319,7 +2319,7 @@
                   },
                   "then" : {
                      "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
-                     "value" : "0.1",
+                     "value" : "0.2",
                      "type" : "Literal"
                   }
                }, {
@@ -2667,48 +2667,44 @@
             "expression" : {
                "type" : "If",
                "condition" : {
-                  "asType" : "{urn:hl7-org:elm-types:r1}Boolean",
-                  "type" : "As",
-                  "operand" : {
-                     "type" : "And",
+                  "type" : "And",
+                  "operand" : [ {
+                     "type" : "LessOrEqual",
                      "operand" : [ {
-                        "type" : "LessOrEqual",
-                        "operand" : [ {
-                           "path" : "value",
+                        "path" : "value",
+                        "type" : "Property",
+                        "source" : {
+                           "name" : "strength",
+                           "type" : "OperandRef"
+                        }
+                     }, {
+                        "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                        "value" : "0.1",
+                        "type" : "Literal"
+                     } ]
+                  }, {
+                     "type" : "Equal",
+                     "operand" : [ {
+                        "type" : "PositionOf",
+                        "pattern" : {
+                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                           "value" : "mg",
+                           "type" : "Literal"
+                        },
+                        "string" : {
+                           "path" : "unit",
                            "type" : "Property",
                            "source" : {
                               "name" : "strength",
                               "type" : "OperandRef"
                            }
-                        }, {
-                           "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
-                           "value" : "0.1",
-                           "type" : "Literal"
-                        } ]
+                        }
                      }, {
-                        "type" : "Equal",
-                        "operand" : [ {
-                           "type" : "PositionOf",
-                           "pattern" : {
-                              "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                              "value" : "mg",
-                              "type" : "Literal"
-                           },
-                           "string" : {
-                              "path" : "unit",
-                              "type" : "Property",
-                              "source" : {
-                                 "name" : "strength",
-                                 "type" : "OperandRef"
-                              }
-                           }
-                        }, {
-                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                           "value" : "0",
-                           "type" : "Literal"
-                        } ]
+                        "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "value" : "0",
+                        "type" : "Literal"
                      } ]
-                  }
+                  } ]
                },
                "then" : {
                   "classType" : "{urn:hl7-org:elm-types:r1}Quantity",
@@ -3082,17 +3078,13 @@
             "expression" : {
                "type" : "If",
                "condition" : {
-                  "asType" : "{urn:hl7-org:elm-types:r1}Boolean",
-                  "type" : "As",
+                  "type" : "IsNull",
                   "operand" : {
-                     "type" : "IsNull",
-                     "operand" : {
-                        "path" : "display",
-                        "type" : "Property",
-                        "source" : {
-                           "name" : "rxNormCode",
-                           "type" : "OperandRef"
-                        }
+                     "path" : "display",
+                     "type" : "Property",
+                     "source" : {
+                        "name" : "rxNormCode",
+                        "type" : "OperandRef"
                      }
                   }
                },
@@ -3160,17 +3152,13 @@
             "expression" : {
                "type" : "If",
                "condition" : {
-                  "asType" : "{urn:hl7-org:elm-types:r1}Boolean",
-                  "type" : "As",
+                  "type" : "IsNull",
                   "operand" : {
-                     "type" : "IsNull",
-                     "operand" : {
-                        "path" : "display",
-                        "type" : "Property",
-                        "source" : {
-                           "name" : "concept",
-                           "type" : "OperandRef"
-                        }
+                     "path" : "display",
+                     "type" : "Property",
+                     "source" : {
+                        "name" : "concept",
+                        "type" : "OperandRef"
                      }
                   }
                },
@@ -3238,17 +3226,13 @@
             "expression" : {
                "type" : "If",
                "condition" : {
-                  "asType" : "{urn:hl7-org:elm-types:r1}Boolean",
-                  "type" : "As",
+                  "type" : "IsNull",
                   "operand" : {
-                     "type" : "IsNull",
-                     "operand" : {
-                        "path" : "display",
-                        "type" : "Property",
-                        "source" : {
-                           "name" : "ingredientCode",
-                           "type" : "OperandRef"
-                        }
+                     "path" : "display",
+                     "type" : "Property",
+                     "source" : {
+                        "name" : "ingredientCode",
+                        "type" : "OperandRef"
                      }
                   }
                },
@@ -3316,17 +3300,13 @@
             "expression" : {
                "type" : "If",
                "condition" : {
-                  "asType" : "{urn:hl7-org:elm-types:r1}Boolean",
-                  "type" : "As",
+                  "type" : "IsNull",
                   "operand" : {
-                     "type" : "IsNull",
-                     "operand" : {
-                        "path" : "display",
-                        "type" : "Property",
-                        "source" : {
-                           "name" : "doseFormCode",
-                           "type" : "OperandRef"
-                        }
+                     "path" : "display",
+                     "type" : "Property",
+                     "source" : {
+                        "name" : "doseFormCode",
+                        "type" : "OperandRef"
                      }
                   }
                },
@@ -3394,27 +3374,23 @@
             "expression" : {
                "type" : "If",
                "condition" : {
-                  "asType" : "{urn:hl7-org:elm-types:r1}Boolean",
-                  "type" : "As",
-                  "operand" : {
-                     "type" : "GreaterOrEqual",
-                     "operand" : [ {
-                        "type" : "LastPositionOf",
-                        "pattern" : {
-                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                           "value" : "/",
-                           "type" : "Literal"
-                        },
-                        "string" : {
-                           "name" : "unit",
-                           "type" : "OperandRef"
-                        }
-                     }, {
-                        "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                        "value" : "0",
+                  "type" : "GreaterOrEqual",
+                  "operand" : [ {
+                     "type" : "LastPositionOf",
+                     "pattern" : {
+                        "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                        "value" : "/",
                         "type" : "Literal"
-                     } ]
-                  }
+                     },
+                     "string" : {
+                        "name" : "unit",
+                        "type" : "OperandRef"
+                     }
+                  }, {
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "value" : "0",
+                     "type" : "Literal"
+                  } ]
                },
                "then" : {
                   "type" : "Substring",
@@ -3518,33 +3494,29 @@
                   "then" : {
                      "type" : "If",
                      "condition" : {
-                        "asType" : "{urn:hl7-org:elm-types:r1}Boolean",
-                        "type" : "As",
-                        "operand" : {
-                           "type" : "In",
-                           "operand" : [ {
-                              "type" : "ToInteger",
-                              "operand" : {
-                                 "path" : "code",
-                                 "type" : "Property",
-                                 "source" : {
-                                    "name" : "ingredientCode",
-                                    "type" : "OperandRef"
-                                 }
+                        "type" : "In",
+                        "operand" : [ {
+                           "type" : "ToInteger",
+                           "operand" : {
+                              "path" : "code",
+                              "type" : "Property",
+                              "source" : {
+                                 "name" : "ingredientCode",
+                                 "type" : "OperandRef"
                               }
+                           }
+                        }, {
+                           "type" : "List",
+                           "element" : [ {
+                              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                              "value" : "1819",
+                              "type" : "Literal"
                            }, {
-                              "type" : "List",
-                              "element" : [ {
-                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                 "value" : "1819",
-                                 "type" : "Literal"
-                              }, {
-                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                 "value" : "4337",
-                                 "type" : "Literal"
-                              } ]
+                              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                              "value" : "4337",
+                              "type" : "Literal"
                            } ]
-                        }
+                        } ]
                      },
                      "then" : {
                         "classType" : "{urn:hl7-org:elm-types:r1}Quantity",
@@ -3928,33 +3900,29 @@
                   "then" : {
                      "type" : "If",
                      "condition" : {
-                        "asType" : "{urn:hl7-org:elm-types:r1}Boolean",
-                        "type" : "As",
-                        "operand" : {
-                           "type" : "In",
-                           "operand" : [ {
-                              "type" : "ToInteger",
-                              "operand" : {
-                                 "path" : "code",
-                                 "type" : "Property",
-                                 "source" : {
-                                    "name" : "ingredientCode",
-                                    "type" : "OperandRef"
-                                 }
+                        "type" : "In",
+                        "operand" : [ {
+                           "type" : "ToInteger",
+                           "operand" : {
+                              "path" : "code",
+                              "type" : "Property",
+                              "source" : {
+                                 "name" : "ingredientCode",
+                                 "type" : "OperandRef"
                               }
+                           }
+                        }, {
+                           "type" : "List",
+                           "element" : [ {
+                              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                              "value" : "1819",
+                              "type" : "Literal"
                            }, {
-                              "type" : "List",
-                              "element" : [ {
-                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                 "value" : "1819",
-                                 "type" : "Literal"
-                              }, {
-                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                 "value" : "4337",
-                                 "type" : "Literal"
-                              } ]
+                              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                              "value" : "4337",
+                              "type" : "Literal"
                            } ]
-                        }
+                        } ]
                      },
                      "then" : {
                         "type" : "Concatenate",

--- a/src/cql/r4/OMTKLogic.json
+++ b/src/cql/r4/OMTKLogic.json
@@ -1340,7 +1340,7 @@
                         },
                         "then" : {
                            "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
-                           "value" : "12.6",
+                           "value" : "15.4",
                            "type" : "Literal"
                         }
                      } ],


### PR DESCRIPTION
See [Slack convo](https://cirg.slack.com/archives/C01P9V67NMA/p1728510815717779)
Change conversion factors:
-  Hydromorphone (from 4 to 6)
- Tramadol (from 0.1 to 0.2)
- Buprenorphine transdermal patch (from 1.8 X 7 = 12.6 to 2.2 X 7 = 15.4 )

Screenshot (using Buprenorphine):
![Screenshot 2024-10-10 at 3 14 35 PM](https://github.com/user-attachments/assets/6e83e9a1-fc8d-44ad-9072-be54dfb145c0)
