### PR TITLE
responses table overflow display issue

### DIFF
--- a/src/styles/components/_Report.scss
+++ b/src/styles/components/_Report.scss
@@ -284,7 +284,7 @@ $selector-box-shadow: 0 2px 2px #383e40;
     }
   }
   .response-table {
-    table-layout: fixed;
+    table-layout: auto;
     border-collapse: separate;
     border-spacing: 0;
     font-size: 0.9em;


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/188476035
Fix Questionnaire Responses table display issue.

Before fix
![Screenshot 2024-10-30 at 3 34 13 PM](https://github.com/user-attachments/assets/d9015563-c33f-4c59-b357-6b47d8c6ad3d)

After fix
![Screenshot 2024-10-30 at 3 37 37 PM](https://github.com/user-attachments/assets/05c1d248-ed27-4abe-a4c9-e9099b878aa0)
