### PR TITLE
MME Graph - spacing, legend styling fixes

### DIFF
--- a/src/components/Summary.js
+++ b/src/components/Summary.js
@@ -697,7 +697,7 @@ export default class Summary extends Component {
               <div className="panels">
                 {this.renderPanel(section, panels, "graph")}
                 {
-                  <div className="sub-panels">
+                  <div className="sub-panels right">
                     {this.renderPanel(section, panels, "rxsummary")}
                     {this.renderPanel(section, panels, "alerts")}
                     {this.renderPanel(section, panels, "surveysummary")}

--- a/src/components/graph/MMEGraph.js
+++ b/src/components/graph/MMEGraph.js
@@ -228,10 +228,10 @@ export default class MMEGraph extends Component {
         <div
           className="legend"
           style={{
-            margin: "10px 0 20px",
+            margin: "0",
             display: "flex",
             flexDirection: "column",
-            gap: "12px",
+            gap: "16px",
           }}
         >
           {oLines.map((item, index) => {
@@ -240,10 +240,13 @@ export default class MMEGraph extends Component {
               <div
                 className="legend__item flex"
                 key={`line_legend_${item.key}_${index}`}
-                style={{ fontSize: "0.7rem" }}
+                style={{ fontSize: "0.68rem", columnGap: "8px" }}
               >
                 <div className="legend__item--key" style={legendProps.style}>
-                  <span className="text">
+                  <span
+                    className="text"
+                    style={{ maxWidth: "88px", display: "inline-block" }}
+                  >
                     {legendProps.label
                       .replace("{Y_FIELD_LABEL}", Y_FIELD_LABEL)
                       .toUpperCase()}
@@ -482,7 +485,7 @@ export default class MMEGraph extends Component {
     const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
     const margins = {
       top: 24,
-      right: 48,
+      right: 32,
       bottom: 56,
       left: 48,
     };

--- a/src/styles/components/_Summary.scss
+++ b/src/styles/components/_Summary.scss
@@ -481,6 +481,12 @@
       @media (min-width: 992px) {
         .panels {
           flex-wrap: nowrap;
+          .sub-section__panel:first-of-type {
+            flex: 1.05 1;
+          }
+          .sub-panels {
+            flex: 0.95 1;
+          }
         }
       }
       .panel.alerts,


### PR DESCRIPTION
- Fix spacing between legend and graph
- Fix legend orphan text, i.e. o in "w/o" text

screenshot before fix:
![BeforeFix](https://github.com/user-attachments/assets/25e9a33f-5aaa-45eb-8a96-efe185abfca9)


screenshot after fix:
![Screenshot 2024-11-15 at 9 25 14 AM](https://github.com/user-attachments/assets/3b528d41-fcbe-4271-b2f7-066ddaf2163b)
