### PR TITLE
fix naloxone alert for active opioid meds  only

### DIFF
--- a/src/config/summary_config.json
+++ b/src/config/summary_config.json
@@ -360,10 +360,34 @@
               },
               {
                 "flag": {
-                  "ifOneOrMore": {
-                    "table": "MedicationRequestsForNaloxoneConsideration",
-                    "source": "RiskConsiderations"
-                  }
+                  "ifAnd": [
+                    {
+                      "ifEqualTo": {
+                        "header": "Class",
+                        "targetValue": "opioid"
+                      }
+                    },
+                    {
+                      "ifGreaterThanOrEqualTo": {
+                        "header": "MME",
+                        "targetValue": 50
+                      }
+                    },
+                    {
+                      "ifEqualTo": {
+                        "header": "isActive",
+                        "type": "boolean",
+                        "targetValue": true
+                      }
+                    },
+                    {
+                      "ifEqualTo": {
+                        "header": "isBup",
+                        "type": "boolean",
+                        "targetValue": false
+                      }
+                    }
+                  ]
                 },
                 "flagText": "Current MME 50 or more, consider prescribing Naloxone",
                 "flagClass": "info"

--- a/src/cql/r4/Factors_to_Consider_in_Managing_Chronic_Pain_FHIRv400.cql
+++ b/src/cql/r4/Factors_to_Consider_in_Managing_Chronic_Pain_FHIRv400.cql
@@ -726,7 +726,8 @@ define ReportPDMPMedicationRequests:
     CalculatedEnd: GetMedicationRequestEndDate(O),
     dispenseRequest:  O.dispenseRequest,
     MME_Object: MMECalculator.MME(O),
-    c: (O.medication as FHIR.CodeableConcept)
+    c: (O.medication as FHIR.CodeableConcept),
+    RxnormCode: Coalesce((c.coding) c2 where c2.system.value ~ 'http://www.nlm.nih.gov/research/umls/rxnorm' return c2.code.value)
     return {
       Type:  'Request',
       Name:  ConceptText(c),
@@ -744,7 +745,9 @@ define ReportPDMPMedicationRequests:
       Prescriber: O.requester.display.value,
       Pharmacy: GetMedicationRequestPharmacy(O),
       NDC_Code: Coalesce((c.coding) c2 where c2.system.value ~ 'http://hl7.org/fhir/sid/ndc' return c2.code.value),
-      RXNorm_Code: Coalesce((c.coding) c2 where c2.system.value ~ 'http://www.nlm.nih.gov/research/umls/rxnorm' return c2.code.value),
+      RXNorm_Code: RxnormCode,
+      isBup: RxnormCode in BuprenorphineRxCUIs,
+      isActive: CalculatedEnd same or after Today(),
       Status: O.status.value,
       Class: getMedicationRequestDrugClass(O),
       AuthoredOn: O.authoredOn

--- a/src/cql/r4/Factors_to_Consider_in_Managing_Chronic_Pain_FHIRv400.json
+++ b/src/cql/r4/Factors_to_Consider_in_Managing_Chronic_Pain_FHIRv400.json
@@ -4607,6 +4607,53 @@
                         "type" : "NamedTypeSpecifier"
                      }
                   }
+               }, {
+                  "identifier" : "RxnormCode",
+                  "expression" : {
+                     "type" : "Coalesce",
+                     "operand" : [ {
+                        "type" : "Query",
+                        "source" : [ {
+                           "alias" : "c2",
+                           "expression" : {
+                              "path" : "coding",
+                              "type" : "Property",
+                              "source" : {
+                                 "name" : "c",
+                                 "type" : "QueryLetRef"
+                              }
+                           }
+                        } ],
+                        "relationship" : [ ],
+                        "where" : {
+                           "type" : "Equivalent",
+                           "operand" : [ {
+                              "path" : "value",
+                              "type" : "Property",
+                              "source" : {
+                                 "path" : "system",
+                                 "scope" : "c2",
+                                 "type" : "Property"
+                              }
+                           }, {
+                              "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                              "value" : "http://www.nlm.nih.gov/research/umls/rxnorm",
+                              "type" : "Literal"
+                           } ]
+                        },
+                        "return" : {
+                           "expression" : {
+                              "path" : "value",
+                              "type" : "Property",
+                              "source" : {
+                                 "path" : "code",
+                                 "scope" : "c2",
+                                 "type" : "Property"
+                              }
+                           }
+                        }
+                     } ]
+                  }
                } ],
                "relationship" : [ ],
                "return" : {
@@ -4885,48 +4932,30 @@
                      }, {
                         "name" : "RXNorm_Code",
                         "value" : {
-                           "type" : "Coalesce",
+                           "name" : "RxnormCode",
+                           "type" : "QueryLetRef"
+                        }
+                     }, {
+                        "name" : "isBup",
+                        "value" : {
+                           "type" : "In",
                            "operand" : [ {
-                              "type" : "Query",
-                              "source" : [ {
-                                 "alias" : "c2",
-                                 "expression" : {
-                                    "path" : "coding",
-                                    "type" : "Property",
-                                    "source" : {
-                                       "name" : "c",
-                                       "type" : "QueryLetRef"
-                                    }
-                                 }
-                              } ],
-                              "relationship" : [ ],
-                              "where" : {
-                                 "type" : "Equivalent",
-                                 "operand" : [ {
-                                    "path" : "value",
-                                    "type" : "Property",
-                                    "source" : {
-                                       "path" : "system",
-                                       "scope" : "c2",
-                                       "type" : "Property"
-                                    }
-                                 }, {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                                    "value" : "http://www.nlm.nih.gov/research/umls/rxnorm",
-                                    "type" : "Literal"
-                                 } ]
-                              },
-                              "return" : {
-                                 "expression" : {
-                                    "path" : "value",
-                                    "type" : "Property",
-                                    "source" : {
-                                       "path" : "code",
-                                       "scope" : "c2",
-                                       "type" : "Property"
-                                    }
-                                 }
-                              }
+                              "name" : "RxnormCode",
+                              "type" : "QueryLetRef"
+                           }, {
+                              "name" : "BuprenorphineRxCUIs",
+                              "type" : "ExpressionRef"
+                           } ]
+                        }
+                     }, {
+                        "name" : "isActive",
+                        "value" : {
+                           "type" : "SameOrAfter",
+                           "operand" : [ {
+                              "name" : "CalculatedEnd",
+                              "type" : "QueryLetRef"
+                           }, {
+                              "type" : "Today"
                            } ]
                         }
                      }, {

--- a/src/helpers/flagit.js
+++ b/src/helpers/flagit.js
@@ -59,7 +59,6 @@ export default function flagit(entry, subSection, summary) {
 function ifAnd(flagRulesArray, entry, subSection, summary) {
   for (let i = 0; i < flagRulesArray.length; ++i) {
     const flagRule = flagRulesArray[i];
-
     let match;
     if (typeof flagRule === 'string') {
       match = functions[flagRule](entry, entry, subSection, summary);
@@ -120,7 +119,8 @@ function ifGreaterThanOrEqualTo(value, entry, subSection, summary) {
   if (Array.isArray(targetEntry) && targetEntry.length) {
     targetEntry = targetEntry[0]
   }
-  return parseInt(targetEntry[value.header], 10) >= value.value;
+  const valueToCompare = value.targetValue != null ? value.targetValue : value.value;
+  return parseInt(targetEntry[value.header], 10) >= valueToCompare;
 }
 /*
  * return true if an entry's value for a field matches the specified target value
@@ -128,6 +128,9 @@ function ifGreaterThanOrEqualTo(value, entry, subSection, summary) {
 function ifEqualTo(value, entry, subSection, summary) {
   if (!entry) return false;
   if (Array.isArray(entry[value.header])) return entry[value.header].indexOf(value.targetValue) !== -1;
+  if (value.type === "boolean") {
+    return Boolean(entry[value.header]) === Boolean(value.targetValue);
+  }
   return entry[value.header] === value.targetValue;
 }
 /*


### PR DESCRIPTION
Per [Slack convo](https://cirg.slack.com/archives/C01P9V67NMA/p1732298819947879)
Display naloxone alert for opioid meds (non-buprenorphine) that the patient is currently taking (as of today)

**screenshot for when the user is currently taking opioid:**
![Screenshot 2024-11-22 at 12 14 26 PM](https://github.com/user-attachments/assets/ea86196d-fc1a-4165-b376-e77c3ede0b4a)

**screenshot for when the user is not currently taking opioid (no alert):**
![Screenshot 2024-11-22 at 12 11 18 PM](https://github.com/user-attachments/assets/c6e27701-c11b-4b67-a1fc-d8fb37a360dc)
