### PR TITLE
handle error when survey has not associated ELM lib

### DIFF
--- a/src/components/Summary.js
+++ b/src/components/Summary.js
@@ -13,6 +13,7 @@ import {
   getErrorMessageString,
   isEmptyArray,
   isReportEnabled,
+  isNumber
 } from "../helpers/utility";
 
 import ChartIcon from "../icons/ChartIcon";
@@ -353,7 +354,7 @@ export default class Summary extends Component {
               ...formatterArguments
             );
           }
-          return value
+          return value || isNumber(value)
             ? value
             : headerKey.default
             ? headerKey.default

--- a/src/config/report_config.js
+++ b/src/config/report_config.js
@@ -60,6 +60,7 @@ const reportConfig = [
       {
         id: "CIRG-PainTracker-GE",
         key: GE_DATA_KEY,
+        useDefaultELMLib: true
       },
     ],
     //status: "inactive",
@@ -380,6 +381,7 @@ const reportConfig = [
       {
         id: "CIRG-PainTracker-TRT",
         key: TRT_DATA_KEY,
+        useDefaultELMLib: true
       },
     ],
     icon: (props) => (

--- a/src/styles/components/_Summary.scss
+++ b/src/styles/components/_Summary.scss
@@ -403,9 +403,10 @@
             height: 100%;
             width: 100%;
             display: flex;
-            align-items: center;
+            align-items: flex-start;
             justify-content: center;
             font-size: 1.1em;
+            line-height: 1.35;
           }
         }
         @media (min-width: 992px) {

--- a/src/utils/executeELM.js
+++ b/src/utils/executeELM.js
@@ -178,7 +178,8 @@ async function executeELM(collector, oResourceTypes) {
               }
             )
             .catch((e) => {
-              console.log("Error processing instrument ELM ", e);
+              console.log("Error processing instrument ELM: ", e);
+              reject("rror processing instrument ELM. See console for details.");
             });
         });
       });

--- a/src/utils/executeELM.js
+++ b/src/utils/executeELM.js
@@ -179,7 +179,7 @@ async function executeELM(collector, oResourceTypes) {
             )
             .catch((e) => {
               console.log("Error processing instrument ELM: ", e);
-              reject("rror processing instrument ELM. See console for details.");
+              reject("error processing instrument ELM. See console for details.");
             });
         });
       });


### PR DESCRIPTION
per [Slack convo](https://cirg.slack.com/archives/C01P9V67NMA/p1733356402568939)

- Allow more graceful handling of error when processing questionnaire ELM lib, i.e. use default lib as specified without raising exception.
- Will not halt on exception anymore in FF
Other fix:
- minor styling fix of error display