### PR TITLE
Frontend logging: add DEA and roles

### DIFF
--- a/src/helpers/utility.js
+++ b/src/helpers/utility.js
@@ -588,19 +588,20 @@ export function writeToLog(message, level, params) {
         username: userId
       };
     }
-  }
-
-  if (Object.keys(logParams).indexOf("DEA") === -1) {
     const dea = getDEAFromAccessToken();
     if (dea) {
-      logParams.DEA = dea;
+      if (!logParams.user) {
+        logParams.user = {};
+      }
+      logParams.user.DEA = dea;
     }
-  }
 
-  if (Object.keys(logParams).indexOf("roles") === -1) {
     const roles = getRealmRolesFromAccessToken();
     if (roles) {
-      logParams.roles = roles;
+      if (!logParams.user) {
+        logParams.user = {};
+      }
+      logParams.user.roles = roles;
     }
   }
 

--- a/src/helpers/utility.js
+++ b/src/helpers/utility.js
@@ -575,6 +575,7 @@ export function writeToLog(message, level, params) {
   const logLevel = level ? level : "info";
   // use Object.assign to prevent modification of original params 
   const logParams = Object.assign({}, params ? params : {});
+
   if (!logParams.tags) logParams.tags = [];
   const COSRI_FRONTEND_TAG = "cosri-frontend";
   if (logParams.tags.indexOf(COSRI_FRONTEND_TAG) === -1) {
@@ -588,6 +589,21 @@ export function writeToLog(message, level, params) {
       };
     }
   }
+
+  if (Object.keys(logParams).indexOf("DEA") === -1) {
+    const dea = getDEAFromAccessToken();
+    if (dea) {
+      logParams.DEA = dea;
+    }
+  }
+
+  if (Object.keys(logParams).indexOf("roles") === -1) {
+    const roles = getRealmRolesFromAccessToken();
+    if (roles) {
+      logParams.roles = roles;
+    }
+  }
+
   const auditURL = `${getEnvConfidentialAPIURL()}/auditlog`;
   const patientName = params.patientName ? params.patientName : "";
   let messageString = "";
@@ -730,6 +746,19 @@ export function getUserIdFromAccessToken() {
   if (accessToken.profile) return accessToken.profile;
   if (accessToken.fhirUser) return accessToken.fhirUser;
   return accessToken["preferred_username"];
+}
+
+export function getDEAFromAccessToken() {
+  const accessToken = getTokenInfoFromStorage();
+  if (!accessToken) return null;
+  return accessToken.DEA;
+}
+
+export function getRealmRolesFromAccessToken() {
+  const accessToken = getTokenInfoFromStorage();
+  if (!accessToken) return null;
+  if (!accessToken["realm_access"]) return null;
+  return accessToken["realm_access"].roles;
 }
 
 export function addMatomoTracking() {


### PR DESCRIPTION
Per [Slack convo](https://cirg.slack.com/archives/C01P9V67NMA/p1735003763009799?thread_ts=1734983390.020329&cid=C01P9V67NMA)
part of the story: https://www.pivotaltracker.com/story/show/188705822
Add `DEA` and `roles` to frontend log entry.
Example data submitted:
```
{
  "patient": "Barney Abbott",
  "message": "overview tab",
  "level": "info",
  "tags": ["tab", "analytics", "cosri-frontend"],
  "patientName": "Barney Abbott",
  "subject": "Patient/5ee05359-57bf-4cee-8e89-91382c07e162",
  "user": {
    "username": "amysbubble",
    "DEA": "FAKEDEA123",
    "roles": [
      "clinician",
      "default-roles-femr",
      "offline_access",
      "uma_authorization"
    ]
  }
}

```