### PR TITLE
remove extraneous timezone conversion code

### DIFF
--- a/src/helpers/utility.js
+++ b/src/helpers/utility.js
@@ -152,9 +152,6 @@ export function getDisplayDateFromISOString(isocDateString, format) {
   if (!isocDateString) return "--";
   const objDate = new Date(isocDateString);
   if (isNaN(objDate)) return "--";
-  // need to account for timezone offset for a UTC date/time
-  let tzOffset = objDate.getTimezoneOffset() * 60000;
-  objDate.setTime(objDate.getTime() + tzOffset);
   const displayDate = objDate
     ? objDate.toLocaleString(
         "en-us",


### PR DESCRIPTION
address https://app.shortcut.com/cirg/story/2026/time-zone-error

- remove extraneous code that converts current date/time back to UTC date/time

Note when system ISO date/time, e.g. 2023-06-02T00:35:56Z is passed into the Javascript Date object, the resulting date/time is converted to current timezone date/time.  No need for further conversion

authored date of 2025-04-01T00:23:55Z
Before fix:
![Screenshot 2025-04-01 at 8 59 42 AM](https://github.com/user-attachments/assets/1132089d-cbaf-4f41-bd85-26a7fe6d38a0)

After fix
![Screenshot 2025-04-01 at 9 00 14 AM](https://github.com/user-attachments/assets/85b12580-0e47-4441-84e6-652c453004ed)

