### PR TITLE
Bugfix/page search request

### DIFF
--- a/src/utils/executeELM.js
+++ b/src/utils/executeELM.js
@@ -425,8 +425,8 @@ function processPage(client, uri, collector, resources) {
           const requestURL = getRequestURL(client, reuseURL.search);
           if (requestURL) o.url = requestURL;
         }
-          if (o.relation === "next")
-            console.log("Next URL ", o.url)
+          // if (o.relation === "next")
+          //   console.log("Next URL ", o.url)
         return o;
       });
       url = bundle.link.find((l) => l.relation === "self").url;

--- a/src/utils/executeELM.js
+++ b/src/utils/executeELM.js
@@ -443,8 +443,6 @@ function updateSearchParams(params, release, type) {
         // nothing
       }
     }
-    //set default count
-    params.set("_count", 300);
   }
   // If this is for Epic, there are some specific modifications needed for the queries to work properly
   if (isEnvEpicQueries()) {

--- a/src/utils/executeELM.js
+++ b/src/utils/executeELM.js
@@ -361,7 +361,9 @@ function getRequestURL(client, uri = "") {
     serverURL = client.state.serverUrl;
   }
   if (!serverURL) return "";
-  return serverURL + (!serverURL.endsWith("/") ? "/" : "") + uri;
+  let uriToUse = uri;
+  if (uriToUse.startsWith("/")) uriToUse = uri.slice(1);
+  return serverURL + (!serverURL.endsWith("/") ? "/" : "") + uriToUse;
 }
 
 function doSearch(client, release, type, collector) {
@@ -423,8 +425,8 @@ function processPage(client, uri, collector, resources) {
           const requestURL = getRequestURL(client, reuseURL.search);
           if (requestURL) o.url = requestURL;
         }
-        //   if (o.relation === "next")
-        //     console.log("Next URL ", o.url)
+          if (o.relation === "next")
+            console.log("Next URL ", o.url)
         return o;
       });
       url = bundle.link.find((l) => l.relation === "self").url;

--- a/src/utils/executeELM.js
+++ b/src/utils/executeELM.js
@@ -228,7 +228,6 @@ async function executeELMForReport(bundle) {
     results = null;
     console.log(`Error executing CQL for report `, e);
   }
-  console.log("Report results", results);
   return results;
 }
 


### PR DESCRIPTION
address issue raised in [Slack convo](https://cirg.slack.com/archives/C01P9V67NMA/p1744771682442419?thread_ts=1744676274.124889&cid=C01P9V67NMA)

- set `_count` to 300 for FHIR resources
- construct page search URL to use FHIR client `serverURL` when applicable
- fix code that returns search results to resolve Promises only when all resources are returned (including those from page searches)

see screenshots:

client.state.serverUrl
<img width="727" alt="Screenshot 2025-04-16 at 10 49 45 AM" src="https://github.com/user-attachments/assets/8dcba39a-2ba5-46e1-8eba-55bf1dcc3502" />

FHIR page searches worked now:
<img width="1389" alt="Screenshot 2025-04-16 at 10 47 15 AM" src="https://github.com/user-attachments/assets/9faf20be-2cd2-403f-be22-3e9a49f0dc78" />

screenshot of all procedures including those from page searches:
![Screenshot 2025-04-16 at 11 05 08 AM](https://github.com/user-attachments/assets/2c128c13-d0f8-4c3f-a430-fd4404860368)





