### PR TITLE
set initial counts for requests

### DIFF
--- a/src/utils/executeELM.js
+++ b/src/utils/executeELM.js
@@ -454,12 +454,13 @@ function updateSearchParams(params, release, type) {
       switch (type) {
         case "Questionnaire":
           params.set("_id", INSTRUMENT_LIST.join(","));
+          params.set("_count", 300);
           break;
         case "QuestionnaireResponse":
           params.set("_sort", "_lastUpdated");
           break;
         default:
-        // nothing
+          params.set("_count", 50);
       }
     }
   }

--- a/src/utils/executeELM.js
+++ b/src/utils/executeELM.js
@@ -454,10 +454,10 @@ function updateSearchParams(params, release, type) {
       switch (type) {
         case "Questionnaire":
           params.set("_id", INSTRUMENT_LIST.join(","));
-          params.set("_count", 300);
           break;
         case "QuestionnaireResponse":
           params.set("_sort", "_lastUpdated");
+          params.set("_count", 300);
           break;
         default:
           params.set("_count", 50);


### PR DESCRIPTION
per [convo](https://cirg.slack.com/archives/C01P9V67NMA/p1744844940353289?thread_ts=1744676274.124889&cid=C01P9V67NMA) in Slack

- Set `_count` ([number of resources per page](https://build.fhir.org/search.html#count)) for QuestionnaireResponse to 300 to reduce the amount of HTTP requests
<img width="808" alt="Screenshot 2025-04-16 at 4 29 08 PM" src="https://github.com/user-attachments/assets/4c15e48b-980c-4c68-9f89-994353fa57d3" />


- Set `_count` to 50 for other FHIR resources (and their additional page requests)

<img width="718" alt="Screenshot 2025-04-16 at 4 29 19 PM" src="https://github.com/user-attachments/assets/2ea0fd24-38e4-4435-9950-1857a4b693a9" />
<img width="955" alt="Screenshot 2025-04-16 at 4 28 35 PM" src="https://github.com/user-attachments/assets/fc38a1c3-fb18-4780-a1ca-fe1a2d361046" />

