### PR TITLE
Update handling of report resource requests

### DIFF
--- a/src/components/DevTools.jsx
+++ b/src/components/DevTools.jsx
@@ -166,7 +166,7 @@ export default class DevTools extends Component {
 
     return (
       <div className="dev-tools">
-        <h3 className="title">
+        <h3 className="title js-toc-ignore">
           Development Tools{" "}
           <button className="button-link" onClick={this.toggleDevTools}>[show/hide]</button>
         </h3>

--- a/src/components/Disclaimer.jsx
+++ b/src/components/Disclaimer.jsx
@@ -43,7 +43,7 @@ export default class Disclaimer extends Component {
           role="button"
           tabIndex={0}
         >
-          <h3 className="title no-margins">
+          <h3 className="title no-margins js-toc-ignore">
             COSRI development and open source software details
           </h3>
           <button className="close-button button-link" title="toggle show/hide">

--- a/src/components/ErrorBanner.jsx
+++ b/src/components/ErrorBanner.jsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faExclamationCircle } from "@fortawesome/free-solid-svg-icons";
 import ChevronDownIcon from "../icons/ChevronDownIcon";
+import { isEmptyArray } from "../helpers/utility";
 
 export default class ErrorBanner extends Component {
   constructor() {
@@ -26,6 +27,7 @@ export default class ErrorBanner extends Component {
   }
 
   render() {
+    if (isEmptyArray(this.props.errors)) return null;
     const conditionalClass = this.state.displayed ? "" : "close";
     return (
       <div

--- a/src/components/Landing/index.jsx
+++ b/src/components/Landing/index.jsx
@@ -382,20 +382,21 @@ export default class Landing extends Component {
     if (this.state.activeTab === index) {
       return;
     }
-    this.setState(
-      {
-        activeTab: index,
-      },
-      () => {
+    if (!this.isTabActivated(index)) {
+      this.setState(
+        (prevState) => ({
+          activeTab: index,
+          tabsActivated: [...prevState.tabsActivated, index],
+        }),
+        () => {
+          window.scrollTo(0, 1);
+        }
+      );
+    } else {
+      this.setState({ activeTab: index }, () => {
         window.scrollTo(0, 1);
-      }
-    );
-    if (this.isTabActivated[index]) {
-      return;
+      });
     }
-    this.setState({
-      tabsActivated: [...this.state.tabsActivated, index],
-    });
   }
 
   shouldShowTabs() {

--- a/src/components/Landing/index.jsx
+++ b/src/components/Landing/index.jsx
@@ -451,7 +451,12 @@ export default class Landing extends Component {
               className={`tab ${
                 this.state.activeTab === index ? "active" : ""
               }`}
-              onClick={() => this.handleSetActiveTab(index)}
+              onClick={(e) => {
+                const parentTab = e.target.closest(".tab");
+                if (parentTab)
+                  parentTab.classList.add("active");
+                this.handleSetActiveTab(index);
+              }}
               role="presentation"
               key={`tab_${index}`}
             >

--- a/src/components/Landing/index.jsx
+++ b/src/components/Landing/index.jsx
@@ -78,10 +78,10 @@ export default class Landing extends Component {
     // display resources loading statuses
     this.initProcessProgressDisplay();
     Promise.allSettled([
-      // fetch env data where necessary, i.e. env.json, to ensure REACT env variables are available
-      fetchEnvData(),
       executeElm(this.state.collector, this.state.resourceTypes),
       landingUtils.getExternalData(summaryMap),
+      // fetch env data where necessary, i.e. env.json, to ensure REACT env variables are available
+      fetchEnvData(),
     ])
       .then((responses) => {
         if (!getTokenInfoFromStorage()) {
@@ -109,8 +109,8 @@ export default class Landing extends Component {
         writeToLog("application loaded", "info", this.getPatientLogParams());
         //set FHIR results
         let result = {};
-        let fhirData = responses[1].value;
-        let externalDataSet = responses[2].value;
+        let fhirData = responses[0]?.value;
+        let externalDataSet = responses[1]?.value;
         // hide and show section(s) depending on config
         const currentSummaryMap = {
           ...this.state.summaryMap,
@@ -486,10 +486,19 @@ export default class Landing extends Component {
               >
                 {item === "overview" &&
                   this.renderSummary(summary, sectionFlags)}
-                {item === "report" && this.isTabActivated(index) && (
+                {item === "report" &&  (
                   <Report
                     patientBundle={this.state.result?.bundle}
                     sectionFlags={sectionFlags}
+                    onReportLoaded={(data) => this.setState({
+                      result: {
+                        ...this.state.result,
+                        Summary: {
+                          ...this.state.result.Summary,
+                          ...data
+                        }
+                      }
+                    })}
                   ></Report>
                 )}
                 {/* other tab panel as specified here */}

--- a/src/components/Landing/index.jsx
+++ b/src/components/Landing/index.jsx
@@ -249,7 +249,6 @@ export default class Landing extends Component {
 
   getPatientId() {
     if (this.state.patientId) return this.state.patientId;
-    if (!this.state.collector) return "";
     const patientResource = this.getPatientResource();
     if (patientResource) return patientResource.id;
     return "";
@@ -348,11 +347,6 @@ export default class Landing extends Component {
         activeTab: index,
       },
       () => {
-        //this.initTocBot();
-        // writeToLog(index >= 1 ? "report tab" : "overview tab", "info", {
-        //   tags: ["tab", "analytics"],
-        //   ...this.getPatientLogParams(),
-        // });
         window.scrollTo(0, 1);
       }
     );

--- a/src/components/Report/index.jsx
+++ b/src/components/Report/index.jsx
@@ -43,7 +43,7 @@ export default class Report extends Component {
 
   componentWillUnmount() {
     destroyTocBot();
-    clearProcessInterval();
+    this.clearProcessInterval();
   }
 
   componentDidMount() {

--- a/src/components/Report/index.jsx
+++ b/src/components/Report/index.jsx
@@ -71,6 +71,9 @@ export default class Report extends Component {
           () => {
             this.clearProcessInterval();
             this.initializeTocBot();
+            if (this.props.onReportLoaded) {
+              this.props.onReportLoaded(this.state.summaryData);
+            }
           }
         );
       })
@@ -88,9 +91,7 @@ export default class Report extends Component {
     this.clearProcessInterval();
     progressIntervalId = setInterval(() => {
       this.setState({
-        loadingMessage: getProcessProgressDisplay(
-          this.state.resourceTypes
-        ),
+        loadingMessage: getProcessProgressDisplay(this.state.resourceTypes),
       });
     }, 30);
   }

--- a/src/components/Summary.jsx
+++ b/src/components/Summary.jsx
@@ -36,6 +36,7 @@ import SideNav from "./SideNav";
 import Table from "./Table";
 import Warning from "./Warning";
 import MMEGraph from "./graph/MMEGraph";
+import { initTocBot, destroyTocBot } from "../config/tocbot_config";
 import Version from "../elements/Version";
 import {
   getErrorMessageString,
@@ -62,6 +63,22 @@ export default class Summary extends Component {
     this.subsectionTableProps = { id: "react_sub-section__table" };
 
     ReactModal.setAppElement("body");
+  }
+  componentDidMount() {
+    const MIN_HEADER_HEIGHT = this.parentContainerRef.current.closest(".active")
+      ? 180
+      : 100;
+    initTocBot({
+      tocSelector: `.overview .summary__nav`, // where to render the table of contents
+      contentSelector: `.overview .summary__display`, // where to grab the headings to build the table of contents
+     // positionFixedSelector: `.overview .summary__nav`, // element to add the positionFixedClass to
+      headingsOffset: 1 * MIN_HEADER_HEIGHT,
+      scrollSmoothOffset: -1 * MIN_HEADER_HEIGHT,
+    });
+  }
+
+  componentWillUnmount() {
+    destroyTocBot();
   }
 
   handleOpenModal = (modalSubSection, event) => {
@@ -435,8 +452,10 @@ export default class Summary extends Component {
           tableKey={tableID}
           tableClass={`${
             columns.length <= 2
-              ? `single-column sub-section__table ${subSection.tableClass??""}`
-              : `sub-section__table ${subSection.tableClass??""}`
+              ? `single-column sub-section__table ${
+                  subSection.tableClass ?? ""
+                }`
+              : `sub-section__table ${subSection.tableClass ?? ""}`
           }`}
           columns={columns}
           data={filteredEntries}

--- a/src/components/Summary.jsx
+++ b/src/components/Summary.jsx
@@ -36,7 +36,10 @@ import SideNav from "./SideNav";
 import Table from "./Table";
 import Warning from "./Warning";
 import MMEGraph from "./graph/MMEGraph";
-import { initTocBot, destroyTocBot } from "../config/tocbot_config";
+import {
+  initTocBot,
+  destroyTocBot,
+} from "../config/tocbot_config";
 import Version from "../elements/Version";
 import {
   getErrorMessageString,
@@ -46,6 +49,7 @@ import {
   isReportEnabled,
 } from "../helpers/utility";
 import { getScoringData } from "./Report/utility";
+import tocbot from "tocbot";
 
 export default class Summary extends Component {
   constructor() {
@@ -54,7 +58,6 @@ export default class Summary extends Component {
     this.state = {
       showModal: false,
       modalSubSection: null,
-      activeTab: 0,
     };
 
     this.elementRef = React.createRef();
@@ -65,20 +68,26 @@ export default class Summary extends Component {
     ReactModal.setAppElement("body");
   }
   componentDidMount() {
-    const MIN_HEADER_HEIGHT = this.parentContainerRef.current.closest(".active")
-      ? 180
-      : 100;
-    initTocBot({
-      tocSelector: `.overview .summary__nav`, // where to render the table of contents
-      contentSelector: `.overview .summary__display`, // where to grab the headings to build the table of contents
-     // positionFixedSelector: `.overview .summary__nav`, // element to add the positionFixedClass to
-      headingsOffset: 1 * MIN_HEADER_HEIGHT,
-      scrollSmoothOffset: -1 * MIN_HEADER_HEIGHT,
-    });
+    this.initializeTocBot();
   }
 
   componentWillUnmount() {
     destroyTocBot();
+  }
+
+  initializeTocBot() {
+    if (!document.querySelector("nav")) return;
+    const isActiveTab = this.parentContainerRef.current.closest(".active");
+    const MIN_HEADER_HEIGHT = isActiveTab ? 180 : 100;
+    const parentSelector = isActiveTab ? ".active": ".overview";
+    destroyTocBot();
+    initTocBot({
+      tocSelector: `${parentSelector} .summary__nav`, // where to render the table of contents
+      contentSelector: `${parentSelector} .summary__display`, // where to grab the headings to build the table of contents
+      positionFixedSelector: `${parentSelector} .summary__nav`, // element to add the positionFixedClass to
+      headingsOffset: 1 * MIN_HEADER_HEIGHT,
+      scrollSmoothOffset: -1 * MIN_HEADER_HEIGHT,
+    });
   }
 
   handleOpenModal = (modalSubSection, event) => {

--- a/src/config/summary_config.json
+++ b/src/config/summary_config.json
@@ -185,7 +185,7 @@
             "type": "surveysummary",
             "title": "Questionnaire Scoring Summary",
             "data": {
-              "dataSectionRefKey": "SurveySummary"
+              "dataSectionRefKey": "survey"
             }
           },
           {

--- a/src/config/tocbot_config.js
+++ b/src/config/tocbot_config.js
@@ -4,16 +4,17 @@ let tocbotTntervalId = 0;
 
 export const defautTocBotOptions = {
   //tocSelector: ".active .summary__nav", // where to render the table of contents
-  tocSelector: `.summary__nav`.trim(), // where to render the table of contents
-  contentSelector: `.summary__display`.trim(), // where to grab the headings to build the table of contents
+  tocSelector: `.summary__nav`, // where to render the table of contents
+  contentSelector: `.summary__display`, // where to grab the headings to build the table of contents
   headingSelector: "h2, h3", // which headings to grab inside of the contentSelector element
-  positionFixedSelector: `.summary__nav`.trim(), // element to add the positionFixedClass to
-  ignoreSelector: "h3.panel-title",
+  positionFixedSelector: `.summary__nav`, // element to add the positionFixedClass to
+  ignoreSelector: "h3.panel-title, .js-toc-ignore",
   collapseDepth: 0, // how many heading levels should not be collpased
   includeHtml: true, // include the HTML markup from the heading node, not just the text,
   headingsOffset: 1 * MIN_HEADER_HEIGHT,
   scrollSmoothOffset: -1 * MIN_HEADER_HEIGHT,
   hasInnerContainers: true,
+  fixedSidebarOffset: "auto",
   onClick: (e) => {
     e.preventDefault();
     const sectionIdAttr = "datasectionid";
@@ -53,13 +54,20 @@ export const defautTocBotOptions = {
 };
 
 export const initTocBot = (options) => {
-    tocbot.init({
-        ...defautTocBotOptions,
-        ...options
-    });
-}
+  tocbot.init({
+    ...defautTocBotOptions,
+    ...options,
+  });
+};
 
 export const destroyTocBot = () => {
-    clearTimeout(tocbotTntervalId);
-    tocbot.destroy();
-}
+  clearTimeout(tocbotTntervalId);
+  tocbot.destroy();
+};
+
+export const refreshTocBot = (options) => {
+  tocbot.refresh({
+    ...defautTocBotOptions,
+    ...options,
+  });
+};

--- a/src/config/tocbot_config.js
+++ b/src/config/tocbot_config.js
@@ -1,0 +1,65 @@
+import tocbot from "tocbot";
+const MIN_HEADER_HEIGHT = 100;
+let tocbotTntervalId = 0;
+
+export const defautTocBotOptions = {
+  //tocSelector: ".active .summary__nav", // where to render the table of contents
+  tocSelector: `.summary__nav`.trim(), // where to render the table of contents
+  contentSelector: `.summary__display`.trim(), // where to grab the headings to build the table of contents
+  headingSelector: "h2, h3", // which headings to grab inside of the contentSelector element
+  positionFixedSelector: `.summary__nav`.trim(), // element to add the positionFixedClass to
+  ignoreSelector: "h3.panel-title",
+  collapseDepth: 0, // how many heading levels should not be collpased
+  includeHtml: true, // include the HTML markup from the heading node, not just the text,
+  headingsOffset: 1 * MIN_HEADER_HEIGHT,
+  scrollSmoothOffset: -1 * MIN_HEADER_HEIGHT,
+  hasInnerContainers: true,
+  onClick: (e) => {
+    e.preventDefault();
+    const sectionIdAttr = "datasectionid";
+    const containgElement = e.target.closest(`[${sectionIdAttr}]`);
+    const sectionId = containgElement
+      ? containgElement.getAttribute(sectionIdAttr)
+      : e.target.getAttribute(sectionIdAttr);
+    //e.stopPropagation();
+    const anchorElement = document.querySelector(`#${sectionId}__anchor`);
+    const listItems = document.querySelectorAll(".toc-list-item");
+    const activeListItem = e.target.closest(".toc-list-item");
+    const tocLinks = document.querySelectorAll(".toc-link");
+    const activeLink = e.target.closest(".toc-link");
+    if (anchorElement) {
+      anchorElement.scrollIntoView(true);
+    } else {
+      e.target.scrollIntoView(true);
+    }
+    clearTimeout(tocbotTntervalId);
+    tocbotTntervalId = setTimeout(() => {
+      tocLinks.forEach((el) => {
+        if (el.isEqualNode(activeLink)) {
+          el.classList.add("is-active-link");
+          return true;
+        }
+        el.classList.remove("is-active-link");
+      });
+      listItems.forEach((el) => {
+        if (el.isEqualNode(activeListItem)) {
+          el.classList.add("is-active-li");
+          return true;
+        }
+        el.classList.remove("is-active-li");
+      });
+    }, 150);
+  },
+};
+
+export const initTocBot = (options) => {
+    tocbot.init({
+        ...defautTocBotOptions,
+        ...options
+    });
+}
+
+export const destroyTocBot = () => {
+    clearTimeout(tocbotTntervalId);
+    tocbot.destroy();
+}

--- a/src/config/tocbot_config.js
+++ b/src/config/tocbot_config.js
@@ -54,10 +54,14 @@ export const defautTocBotOptions = {
 };
 
 export const initTocBot = (options) => {
-  tocbot.init({
-    ...defautTocBotOptions,
-    ...options,
-  });
+  try {
+    tocbot.init({
+      ...defautTocBotOptions,
+      ...options,
+    });
+  } catch (e) {
+    console.log("Error initializing tocbot ", e);
+  }
 };
 
 export const destroyTocBot = () => {
@@ -65,9 +69,10 @@ export const destroyTocBot = () => {
   tocbot.destroy();
 };
 
-export const refreshTocBot = (options) => {
-  tocbot.refresh({
-    ...defautTocBotOptions,
-    ...options,
-  });
+export const refreshTocBot = () => {
+  try {
+    tocbot.refresh();
+  } catch(e) {
+    console.log("tocbot refresh error ", e);
+  }
 };

--- a/src/elements/Spinner.jsx
+++ b/src/elements/Spinner.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 const Spinner = (props) => {
   return (
-    <div>
+    <div className="spinner-container">
       <div className="loading-message" dangerouslySetInnerHTML={{ __html: props.loadingMessage }}></div>
       <div className="spinner" role="img" aria-label="Loading">
         <div className="bounce1"></div>

--- a/src/styles/components/_Report.scss
+++ b/src/styles/components/_Report.scss
@@ -5,14 +5,13 @@ $selector-box-shadow: 0 2px 2px #383e40;
   margin: auto;
   .spinner-container {
     position: absolute;
-    left: 50%;
+    left: 48%;
     top: 25%;
-    transform: translate(-25%, -50%);
+    transform: translate(-25%, -48%);
     .loading-message {
       position: relative;
-      top: 32px;
-      left: 50%;
-      font-size: 1.1rem;
+      top: 40px;
+      left: 62%;
     }
   }
   &.summary {

--- a/src/styles/components/_Report.scss
+++ b/src/styles/components/_Report.scss
@@ -3,6 +3,18 @@ $selector-box-shadow: 0 2px 2px #383e40;
 .report {
   padding: 0;
   margin: auto;
+  .spinner-container {
+    position: absolute;
+    left: 50%;
+    top: 25%;
+    transform: translate(-25%, -50%);
+    .loading-message {
+      position: relative;
+      top: 32px;
+      left: 50%;
+      font-size: 1.1rem;
+    }
+  }
   &.summary {
     height: 100%;
     background-color: $color-gray-lightest;

--- a/src/styles/components/_Report.scss
+++ b/src/styles/components/_Report.scss
@@ -5,13 +5,17 @@ $selector-box-shadow: 0 2px 2px #383e40;
   margin: auto;
   .spinner-container {
     position: absolute;
-    left: 48%;
+    left: 40%;
     top: 25%;
-    transform: translate(-25%, -48%);
+    transform: translate(-25%, -25%);
     .loading-message {
       position: relative;
-      top: 40px;
-      left: 62%;
+      top: 48px;
+      left: 25%;
+      transform: translateX(-25%);
+    }
+    .spinner {
+      left: 25%;
     }
   }
   &.summary {

--- a/src/styles/components/_Summary.scss
+++ b/src/styles/components/_Summary.scss
@@ -285,12 +285,12 @@
     }
   }
 
-  &__display,
   &__display {
     flex: 1;
     background-color: $color-gray-lightest;
     z-index: 10;
     max-width: 100%;
+    min-height: 70vh;
     @media (min-width: 768px) {
       & {
         max-width: calc(100% - $summary-nav-base-width);

--- a/src/styles/components/_Summary.scss
+++ b/src/styles/components/_Summary.scss
@@ -686,6 +686,7 @@
         .sub-section__panel {
           display: flex;
           flex-wrap: nowrap;
+          overflow: hidden;
           .panel-overview {
             margin-left: 24px;
           }

--- a/src/styles/components/_Summary.scss
+++ b/src/styles/components/_Summary.scss
@@ -686,7 +686,9 @@
         .sub-section__panel {
           display: flex;
           flex-wrap: nowrap;
-          overflow: hidden;
+          &:has(.no-entry) {
+            overflow: hidden;
+          }
           .panel-overview {
             margin-left: 24px;
           }

--- a/src/styles/elements/_banners.scss
+++ b/src/styles/elements/_banners.scss
@@ -55,8 +55,8 @@
 
     .warning-inside {
       width: 450px;
-      background-color: $color-orange-light;
-      color: $color-orange;
+      background-color:  $color-orange;
+      color: #FFF;
       padding: 10px;
       font-weight: 600;
     }

--- a/src/styles/elements/_tabs.scss
+++ b/src/styles/elements/_tabs.scss
@@ -30,6 +30,7 @@ $tab-polygon: polygon(4.5% 5%, 94.5% 5%, 100% 100%, 0% 100%);
   border-top: 1px solid $tab-inactive-background-color;
   border-left: 1px solid $tab-inactive-background-color;
   border-right: 1px solid $tab-inactive-background-color;
+
   &:not(.active):hover {
     background-color: $color-blue-darker;
     color: #FFF;
@@ -98,8 +99,5 @@ $tab-polygon: polygon(4.5% 5%, 94.5% 5%, 100% 100%, 0% 100%);
   display: none;
   &.active {
     display: block;
-    // &.multi-tabs {
-    //   border-top: 4px solid $color-blue;
-    // }
   }
 }

--- a/src/utils/executePainFactorsELM.js
+++ b/src/utils/executePainFactorsELM.js
@@ -131,7 +131,7 @@ async function executeELM(collector = [], paramResourceTypes = {}) {
         library = getLibrary(release);
         // return all the requests that have been resolved // rejected
         return Promise.allSettled(
-          [...new Set([...extractResourcesFromELM(library)])].map((name) => {
+          [...new Set([...extractResourcesFromELM(library)].sort())].map((name) => {
             resourceTypes[name] = false;
             return doSearch(client, release, name, collector, resourceTypes);
           })

--- a/src/utils/executePainFactorsELM.js
+++ b/src/utils/executePainFactorsELM.js
@@ -184,11 +184,11 @@ async function executeELMForFactors(bundle, patientSource, library) {
   const codeService = new VSACAwareCodeService(valueSetDB);
   const executor = new cql.Executor(library, codeService);
   //debugging
-  console.log("bundle loaded? ", bundle);
-  console.log(
-    "resource types",
-    getResourceTypesFromPatientBundle(bundle?.entry)
-  );
+  // console.log("bundle loaded? ", bundle);
+  // console.log(
+  //   "resource types",
+  //   getResourceTypesFromPatientBundle(bundle?.entry)
+  // );
   patientSource.loadBundles([bundle]);
   let execResults;
   try {

--- a/src/utils/executeReportELM.js
+++ b/src/utils/executeReportELM.js
@@ -150,7 +150,6 @@ async function executeELMForReport(patientSource) {
     reportLib,
     new VSACAwareCodeService({})
   );
-  // patientSource.loadBundles([bundle]);
   let results;
   try {
     results = reportExecutor.exec(patientSource);
@@ -176,7 +175,6 @@ async function executeELMForInstrument(
       id: getReportInstrumentIdByKey(instrumentKey),
     }
   );
-  // surveyPatientSource.loadBundles([bundle]);
   let surveyResults;
   try {
     surveyResults = surveyExecutor.exec(surveyPatientSource);

--- a/src/utils/executeReportELM.js
+++ b/src/utils/executeReportELM.js
@@ -1,0 +1,210 @@
+import FHIR from "fhirclient";
+import cql from "cql-execution";
+import extractResourcesFromELM from "./extractResourcesFromELM";
+import r4HelpersELM from "../cql/r4/FHIRHelpers.json";
+import r4SurveyCommonELM from "../cql/r4/survey_resources/Common_LogicLibrary.json";
+import {
+  getReportInstrumentList,
+  getReportInstrumentIdByKey,
+  getReportLogicLibrary,
+  isEmptyArray,
+} from "../helpers/utility";
+import {
+  doSearch,
+  FHIR_RELEASE_VERSION_4,
+  getPatientSource,
+  getResourcesFromBundle,
+  getResourceTypesFromPatientBundle,
+  VSACAwareCodeService,
+} from "./executePainFactorsELM";
+
+async function executeReportELM(
+  paramPatientBundle,
+  collector = [],
+  paramResourceTypes = {}
+) {
+  let client,
+    release = FHIR_RELEASE_VERSION_4,
+    patientBundle = paramPatientBundle;
+  let resourceTypes = paramResourceTypes || {};
+  const resourceLoaded = getResourceTypesFromPatientBundle(
+    patientBundle?.entry
+  );
+  const SURVEY_FHIR_RESOURCES = ["QuestionnaireResponse", "Questionnaire"];
+  return new Promise((resolve, reject) => {
+    const reportResources = extractResourcesFromELM(getReportLibrary());
+    const resourcesToLoad = reportResources.filter(
+      (resource) => resourceLoaded.indexOf(resource) === -1
+    );
+    FHIR.oauth2
+      .ready()
+      .then((clientArg) => {
+        client = clientArg;
+        return Promise.allSettled(
+          [...new Set([...resourcesToLoad, ...SURVEY_FHIR_RESOURCES])].map(
+            (name) => {
+              resourceTypes[name] = false;
+              if (name === "Patient") {
+                resourceTypes[name] = true;
+                return [pt];
+              }
+              return doSearch(client, release, name, collector, resourceTypes);
+            }
+          )
+        );
+      })
+      .catch((e) => {
+        console.log("client requests error ", e);
+        throw new Error("Client requests error.");
+      })
+      .then((requestResults) => {
+        if (isEmptyArray(requestResults)) {
+          return null;
+        }
+        let resources = requestResults
+          .filter(
+            (result) =>
+              result.state !== "rejected" && !isEmptyArray(result.value)
+          )
+          .map((result) => {
+            return getResourcesFromBundle(result.value);
+          })
+          .flat();
+        patientBundle = {
+          resourceType: "Bundle",
+          entry: [
+            ...new Set([
+              ...(paramPatientBundle.entry ? paramPatientBundle.entry : []),
+              ...resources,
+            ]),
+          ],
+        };
+        const patientSource = getPatientSource(release);
+        // return a promise containing survey evaluated data
+        return Promise.allSettled([
+          // report
+          executeELMForReport(patientBundle, patientSource),
+          // surey results
+          ...executeELMForInstruments(patientBundle, patientSource),
+        ]);
+      })
+      .catch((e) => {
+        reject(e);
+      })
+      .then((results) => {
+        if (results[0].status === "rejected") {
+          console.log("Executing ELM for Report error ", results[0].reason);
+        }
+        let evalResults = {};
+        const getPatientResults = (result) =>
+          result && result.patientResults
+            ? result.patientResults[Object.keys(result.patientResults)[0]]
+            : {};
+        const reportResults = getPatientResults(
+          results[0].status !== "rejected" ? results[0].value : null
+        );
+        evalResults["ReportSummary"] = reportResults.Summary
+          ? reportResults.Summary
+          : null;
+        const surveyLibResults = results
+          .slice(1)
+          .filter((result) => !!result.value);
+        if (isEmptyArray(surveyLibResults)) {
+          resolve(evalResults);
+        }
+        const evaluatedSurveyResults = surveyLibResults
+          .filter((o) => o.value && o.value.patientResults)
+          .map((o) => getPatientResults(o.value));
+        evalResults["SurveySummary"] = evaluatedSurveyResults;
+        //debug
+        console.log(
+          "final evaluated CQL results including surveys ",
+          evalResults
+        );
+        resolve(evalResults);
+      })
+      .catch((e) => {
+        reject(e);
+      });
+  });
+}
+
+function getReportLibrary() {
+  let r4ReportCommonELM = getReportLogicLibrary();
+  if (!r4ReportCommonELM) return null;
+  return new cql.Library(
+    r4ReportCommonELM,
+    new cql.Repository({
+      FHIRHelpers: r4HelpersELM,
+    })
+  );
+}
+
+async function executeELMForReport(bundle, patientSource) {
+  if (!bundle || !patientSource) return null;
+  let reportLib = getReportLibrary();
+  if (!reportLib) return null;
+  const reportExecutor = new cql.Executor(
+    reportLib,
+    new VSACAwareCodeService({})
+  );
+  patientSource.loadBundles([bundle]);
+  let results;
+  try {
+    results = reportExecutor.exec(patientSource);
+  } catch (e) {
+    results = null;
+    console.log(`Error executing CQL for report `, e);
+  }
+  return results;
+}
+
+async function executeELMForInstrument(
+  instrumentKey,
+  library,
+  bundle,
+  surveyPatientSource
+) {
+  if (!instrumentKey || !library || !bundle || !surveyPatientSource)
+    return null;
+  const surveyExecutor = new cql.Executor(
+    library,
+    new VSACAwareCodeService({}),
+    {
+      dataKey: instrumentKey,
+      id: getReportInstrumentIdByKey(instrumentKey),
+    }
+  );
+  surveyPatientSource.loadBundles([bundle]);
+  let surveyResults;
+  try {
+    surveyResults = surveyExecutor.exec(surveyPatientSource);
+  } catch (e) {
+    surveyResults = null;
+    console.log(`Error executing CQL for ${instrumentKey} `, e);
+  }
+  return surveyResults;
+}
+
+function executeELMForInstruments(patientBundle, patientSource) {
+  const INSTRUMENT_LIST = getReportInstrumentList();
+  if (!INSTRUMENT_LIST) return null;
+  if (!patientBundle || !patientSource) return null;
+  const repository = new cql.Repository({
+    FHIRHelpers: r4HelpersELM,
+    Common_LogicLibrary: r4SurveyCommonELM,
+  });
+  return INSTRUMENT_LIST.map((item) =>
+    (async () => {
+      const evalResults = executeELMForInstrument(
+        item.key,
+        new cql.Library(item.library, repository),
+        patientBundle,
+        patientSource
+      );
+      return evalResults;
+    })()
+  );
+}
+
+export default executeReportELM;

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -9,6 +9,14 @@ export default defineConfig({
   base: "/",
   envPrefix: "REACT_",
 
+  css: {
+    preprocessorOptions: {
+      scss: {
+        api: "modern-compiler",
+      },
+    },
+  },
+
   plugins: [
     react(),
     nodePolyfills({
@@ -67,7 +75,7 @@ export default defineConfig({
           if (/src[/\\]config[/\\]report\_config\.js/.test(id)) {
             return "report-config-chunk";
           }
-        }
+        },
       },
     },
   },
@@ -84,4 +92,3 @@ export default defineConfig({
     },
   },
 });
-


### PR DESCRIPTION
Part of the [story](https://app.shortcut.com/cirg/story/2132/review-uw-prod-with-front-end-tools-to-identify-performance-bottlenecks)

- code changes to delay firing off HTTP requests for FHIR resources for Report, i.e. after resources for the Overview tab have been loaded - this will reduce the number of HTTP requests for FHIR resources on initial page load to reduce load time

code changes include:
- extract out code related to extracting and executing Report resources from `executeELM.js`  to separate js file, i.e. `executeReportELM.js`
- move code for initializing tocbot to separate JS file for re-usability purpose 
- add cleanup code for when a component is un-mounted, e.g. remove event listener, clear timer intervals, to prevent memory leak

